### PR TITLE
modify: generate doc_id corresponding to paths with extra_segments in data_entry_server on data_entry_server

### DIFF
--- a/data_entry_server/src/data_entry_logic.py
+++ b/data_entry_server/src/data_entry_logic.py
@@ -180,9 +180,11 @@ def _author_db_linkset_document(data_entry_format):
             return {"response_status": 400, "error": "Invalid data format: " + str(data_entry_format)}
 
         default_linktype = data_entry_format['defaultLinktype']
+        
+        doc_id = convert_path_to_document_id( data_entry_format["anchor"])
 
         database_doc = {
-            "_id": data_entry_format["anchor"].split('/')[-2] + '_' + data_entry_format["anchor"].split('/')[-1],
+            "_id": doc_id,
             "defaultLinktype": default_linktype,
             "data": []
         }
@@ -366,6 +368,16 @@ def _author_db_linkset_list(data_list):
         # If there's any exception during processing, return a server error response
         print('_author_mongo_linkset_list: Error processing document: ', str(e))
         return {"response_status": 500, "error": "Internal Server Error - " + str(e)}
+
+def convert_path_to_document_id(path: str):
+    if path.count('/') < 2:
+        print("Error: path fomrant error")
+        raise ValueError("Error: path fomrant error")
+    
+    parts = path.strip().split('/')
+    parts = [p for p in parts if p != '']
+
+    return '_'.join(parts)
 
 
 def create_document(data):

--- a/data_entry_server/src/data_entry_namespace.py
+++ b/data_entry_server/src/data_entry_namespace.py
@@ -131,3 +131,23 @@ class DocOperations(TokenResource):
         except Exception as e:
             logger.warning('Error deleting document: ' + str(e))
             abort(450, description="Error deleting document")
+
+
+@data_entry_namespace.route('/<anchor_ai_code>/<anchor_ai>/<path:extra_segments>')
+class DocOperations(TokenResource):
+    @api.doc(description="Retrieve a document using its anchor")
+    def get(self, anchor_ai_code, anchor_ai, extra_segments):
+        try:
+            token_result = self.is_auth_token_ok()
+            if not token_result['result'] and token_result['message'] == "Missing Authorization Header":
+                return token_result['message'], 401
+            elif not token_result['result']:
+                return token_result['message'], 403
+        
+            document_id = data_entry_logic.convert_path_to_document_id(f"/{anchor_ai_code}/{anchor_ai}/{extra_segments}")
+            response_data = data_entry_logic.read_document(document_id)
+            return response_data, response_data['response_status']
+
+        except Exception as e:
+            logger.warning('Error getting document ' + str(e))
+            abort(500, description="Error getting document")


### PR DESCRIPTION
## バグの詳細と原因
web_server/src/web_server側で`/01/05392000229663/21/99999`のようなパスを指定し、GETを実行した際にDigital Linkの取得に失敗する原因として、新たなDigital Linkデータを加えるようのサーバーであるdata_entry_serverにおいて、データの挿入時のdoc_id生成方法に問題があった。

data_entry_logic.pyの185行目にあるように、doc_idの生成において、**最後の2つのセグメントのみ**を抽出してアンダースコア`_ `で結合する仕様になっていた。すなわち、データベース側で保存されるデータのdoc_idはanchorプロパティで指定したDigital Linkの最後の2つのセグメントをもとに生成される。(以下がその例)
```
/01/05392000229663/21/99999 => 21_99999
```

しかし、`GET http://localhost:8080/01/05392000229663/21/99999`を実行した際、web_server/src/web_namespace.pyの175行目にあるように、データ取得の際のdoc_idは`f'{anchor_ai_code}_{anchor_ai}'`で構成され、リクエストのパスにおける**最初の2つのセグメント**をもとにdoc_idを生成していた。(以下がその例)
```
/01/05392000229663/21/99999 => 01_05392000229663
```

## 修正方法
convert_path_to_document_id関数を新たに作成し、anchorプロパティで指定されたパス全体からdoc_idを生成するように修正した。
```
/01/05392000229663/21/99999 => 01_05392000229663_21_99999
```

また、data_entry_serverにおいて、`GET /<anchor_ai_code>/<anchor_ai>`のエンドポイントの処理はあるものの、`GET /<anchor_ai_code>/<anchor_ai>/<path:extra_segments>`がなかったため、新たに追加した。