### PR TITLE
fix: Handling Query Parameters in Request Processing

### DIFF
--- a/web_server/src/web_namespace.py
+++ b/web_server/src/web_namespace.py
@@ -329,7 +329,7 @@ def _process_response(doc_id, identifiers, qualifier_path=None, compress=None, q
         response.headers['Location'] = response_data['data']['href']
         # if we have any query_strings then we need to append them to response.headers['Location']:
         if query_strings:
-            response.headers['Location'] += '?' + query_strings
+            response.headers['Location'] += '&' + query_strings if '?' in response.headers['Location'] else '?' + query_strings
 
         return response
 


### PR DESCRIPTION
**Issue**

In Resolver Version 3.0, when resolving a URL with query parameters, the implementation simply appends the incoming query parameters to the service URL saved in the database.

However, if the saved service URL already includes its own query parameters, the additional parameters are concatenated using `?` instead of `&`.

This results in an invalid URL structure, causing the redirect to fail.

**Example**

Request:
```
https://link-dev1.gs1jp.org/01/04595058836016/10/XYZ987?17=250528
```

Registered service URL:
```
https://rdgexp.gs1jp.org/dltest/samplepage/bakery/purchased/cutlet_sandwich/?lot=XYZ987
```
Actual redirect result (invalid):
```
https://rdgexp.gs1jp.org/dltest/samplepage/bakery/purchased/cutlet_sandwich/?lot=XYZ987?17=250528
```

**Cause**

In [web_server/src/web_namespace.py](https://github.com/gs1/GS1_DigitalLink_Resolver_CE/blob/7aa58ac934970ab66a6a126439f8b1396b42ee0e/web_server/src/web_namespace.py#L332), the code assumes that the service URL does not already contain any query parameters.

Relevant code:
```python
response.headers['Location'] = response_data['data']['href']
if query_strings:
    response.headers['Location'] += '?' + query_strings
```

**Solution**
I fixed the implementation so that if the service URL already contains a `?`, the additional query parameters will be concatenated using `&` instead of `?`.This prevents invalid URL structures and ensures a correct redirect.

**Updated code:**
```python
response.headers['Location'] += '&' + query_strings if '?' in response.headers['Location'] else '?' + query_strings
```


Let me know if you’d like me to clarify or adjust any part of this.